### PR TITLE
梯隊Create 專案. clj

### DIFF
--- a/專案. clj
+++ b/專案. clj
@@ -1,0 +1,23 @@
+(defproject echelon "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 ;[com.datomic/datomic-free "0.9.5067"]
+                 [org.clojure/data.json "0.2.5"]
+                 [me.raynes/fs "1.4.4"]
+                 [com.rpl/specter "0.0.6"]
+                 [instaparse "1.3.2"]
+                 [org.clojure/tools.cli "0.3.1"]
+                 [org.jordanlewis/data.union-find "0.1.0"]
+                 [clj-time "0.7.0"]
+                 [environ "0.5.0"]
+                 [com.taoensso/timbre "3.2.1"]
+                 [incanter "1.5.5"]]
+  :plugins [[lein-environ "0.5.0"]]
+  :profiles {:dev
+             [:user {:jvm-opts ["-Xmx4g" "-Xms1g"]}]
+             :prod
+             [:user {:jvm-opts ["-Xmx4g" "-Xms1g" "-server"]}]}
+  :main echelon.simple)


### PR DESCRIPTION
ECHELON 是一個專案,旨在彌補美國政府在披露和公開數據方面的不足。由於公佈的數據品質差,關於我國政府工作的簡單問題難以回答,而有用的問題往往無法回答。ECHELON使用各種計算技術和巧妙的資料庫設計,以克服試圖根據有限的公開資訊在計算機內部類比政府的障礙。

撇開總體概括不談,ECHELON的主要目的有三個。首先,ECHELON 從政府那裡收集數據,並以有用的方式進行結構。這是透過建立模型派生從給定資料的領域專業知識,然後插入到Datomic,一個奇怪的資料庫與強大的查詢引擎。載入資料後,ECHELON 不僅僅是透過使用記錄連結和資訊提取技術來增強資料,從而提供更好的介面。特別是,這意味著我們可以找出的東西名為"大公司公司(以前稱為小公司公司)"代表相同的"小公司公司"。最後,ECHELON 旨在為參與政府工作的各種生物提供持久可靠的 ID。

ECHELON 是一項正在進行中的工作,目前僅從參議院遊說披露網站中收集數據,並且僅執行簡單的計算,以解決數據中的各種內容。我們還有許多其他數據源,我們有興趣拉,並正在努力不斷地儘快攝入它們。當然,還有更複雜的記錄連結和資訊提取技術,我們想探討。

使用
首先,我們當前在具有 32 個內核和 60 GB 記憶體的 EC2 實例上運行 ECHELON。將數據載入到 datomic 中可能需要一兩個小時以上,最簡單的解析度步驟至少需要十分鐘才能運行。我們正在研究一個更複雜的步驟,從基於 Instaparse 的遊說表單中提取簡化的名稱,雖然理論上應該工作正常,但儘管堆大小為 40 GB,卻會引發記憶體錯誤。同樣,這是一項正在進行中的大量工作。

為硬體安裝相應的 JVM。

下載Datomic 免費版,並解壓縮它的地方,它可以佔用至少 20 GB 的磁碟空間。

安裝萊寧根。

從這裡下載資料。這是一個壓縮的目錄,這是從參議院披露網站清理的刮資料版本。解開這個, 把它放在安全的地方。未保存,此檔應為 2.6G。尚未設置任何系統來使 S3 上的數據保持最新,因此,如果您在運行載入文本時遇到任何問題,請在 github 上提交問題,我們將確保數據完全更新。

啟動達托米奇。您將需要提供達托米奇與文件裡面的路徑。下面是如何啟動 datomic 的範例:transactor.propertiesechelon/resources

$ cd ~/software/datomic/
$ bin/transactor -Xmx4g ~/software/echelon/resources/transactor.properties
Launching with Java options -server -Xms1g -Xmx10g -XX:+UseG1GC -XX:MaxGCPauseMillis=50
Starting datomic:free://localhost:4334/<DB-NAME>, storing data in: data ...
System started datomic:free://localhost:4334/<DB-NAME>, storing data in: data
一旦datomic開始,它的時間載入到數據。環境變數,用於提供下載和解壓縮數據的位置。此步驟將載入、處理所有生成的datom並將保存到磁碟。JVM 的預設堆大小為 20gb。在載入過程中,這可能會安全地關閉到 10gb 以下。DATA_LOCATION

$ cd ~/software/echelon
$ DATA_LOCATION=~/data/sopr_html lein with-profile +user,+prod run load
最後,有幾種方法用於解析實體。目前,我們評估解決步驟最有效的方式是查看匹配實體的名稱。因此,所有指令都將建立檔案 。此檔案將具有類似於以下內容的結構的向量清單:output/names-output.clj

[17592186297621
("AEROSPACE MISSIONS CORPORATION" "Aerospace Missions Corporation")]
[17592190608335 ("AES Corporation" "AES Corp")]
[17592191194294 ("AES Sparrows Point LNG, LLC")]
[17592195354891 ("AES Wind Generation" "AES Wind Generation, Inc.")]
[17592191304138 ("AESTI")]
[17592195340675 ("AETNA INC." "AETNA" "Aetna Inc." "Aetna, Inc.")]
[17592195436234 ("AETNA INC.  (Formerly, AETNA LIFE & CASUALTY)")]
[17592188160497 ("AETREX WORLDWIDE, INC.")]
[17592189483957
("AFC FIRST FINANCIAL CORPORATION d/b/a GREAT BEAR FINANCIAL")]
[17592188989049
("AFFILIATED COMPUTER SERVICES, INC.-STATE AND LOCAL SOLUTIONS")]
[17592199962992
("AFFILIATED MANAGERS GROUP, Inc."
"Affiliated Managers Group, Inc.")]
[17592197543002
("AFFORD (formerly Climate Policy Group)"
"AFFORD, Formerly Climate Policy Group")]
[17592199047305 ("AFFORD Group (formerly Climate Policy Group)")]
[17592190928110
("AFFORDABLE HOUSING TAX CREDIT COALITION"
"Affordable Housing Tax Credit Coalition")]
每個向量表示資料庫中的一個狀態。向量的第一個元素是來自存在達托姆的實體 ID。向量的第二個元素是對應於與包含關聯的各種名稱的字串清單。正如我們在上面看到的,並且都與同一個生活有關,而它有自己的人。"AETNA INC.""AETNA""Aetna INC.""Aetna,Inc.""AETNA INC. (Formerly, AETNA LIFE & CASUALTY)"

目前有三個解決步驟。第一個和最簡單的依賴於遊說表格上的複選框,該複選框指示註冊人與用戶端相同。

$ lein with-profile +user,+prod run match same-on-form
下一步,在增加複雜性方面,根據名稱匹配一些生物。特別是,如果用戶端、外國實體、註冊人或附屬組織的表示具有相同的確切名稱,則它們所表示的生命將合併在一起。請注意,我們並不完全根據名稱匹配來匹配人員。

$ lein with-profile +user,+prod run match exact-name
使用的第三步也是最後一步,是目前工作的重點。ECHELON使用 instaparse 和正式語法來解析以前匹配到數據結構中的相同名稱。然後,數據結構結果用於將表示項匹配在一起,並指示應合併哪些生物。

(require '[echeon.text :refer [extract-names]])
(extract-names "Independent School District No. 1 of Tulsa County, Oklahoma a/k/a Tulsa Public School")
;;[["independent" "school" "district" [:number "1"] "of" "tulsa" "county" "oklahoma"]
;; :aka
;; ["tulsa" "public" "school"]]
(extract-names "Terminix, International Co. Lp.")
;;[["terminix" :international :company :lp]]
(extract-names "GenCorp Inc./Aerojet Rocketdyne Inc. (fka Aerojet General Corporation)")
;;[["gencorp" :incorporated "aerojet" "rocketdyne" :incorporated]
;; :fka
;; ["aerojet" "general" :corporation]]
雖然使用解析器嘗試解析自由文本英語似乎很可笑,但我們發現填寫這些表格的說客是習慣的產物。許多相同的模式和詞彙都一遍又一遍地出現,因此這些名稱欄位中的文本的結構比人們想像的要多。雖然可能無法對欄位進行明確的分析,但無需過多的努力,即可從欄位中獲取相當有用的資訊。

$ lein with-profile +user,+prod run match extracted-name
也可以按順序運行上述所有步驟。

$ lein with-profile +user,+prod run match extracted-name
最後,匹配步驟將生成解析度保存到磁碟。這意味著,運行一個步驟不止一次目前不會產生更好的結果。

挑戰
概述是表示及其意義。
關於檔表示的選擇的檔。
發現更好的指標,說明解決步驟的完成。
編寫更好的解析度步驟並擴展解析器識別各種實體名稱的二致。